### PR TITLE
Update to PlotSquared 5.12.0 (Fixes PS-28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Plot2Dynmap
 ===========
 
-Dynmap addon for PlotSquared 4.
+Dynmap addon for PlotSquared 5.
 
 ## Links
 - Downloads: [link](https://ci.athion.net/job/Plot2Dynmap/)

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,9 @@ repositories {
 }
 
 dependencies {
-    compile 'com.plotsquared:PlotSquared:5.1'
+    compileOnly(group: 'com.github.intellectualsites.PlotSquared', name: 'PlotSquared-Core', version: 'b9b0d89b5f759354a684cd7a6539ae7e4b883ba2') {
+        exclude(module: 'worldedit-core')
+    }
     compile 'org.spigotmc:spigot-api:1.15.2-R0.1-SNAPSHOT'
     compile(group: 'com.sk89q.worldedit', name: 'worldedit-bukkit', version: '7.2.0-SNAPSHOT')
     compile('us.dynmap:dynmap:3.0-SNAPSHOT'){ transitive = false }

--- a/build.gradle
+++ b/build.gradle
@@ -8,16 +8,14 @@ repositories {
     jcenter()
     mavenCentral()
     maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
-    maven { url "https://ci.athion.net/job/PlotSquared-Breaking/ws/mvn/" }
     maven { url "https://hub.spigotmc.org/nexus/content/repositories/snapshots/" }
-    maven { url "https://jitpack.io" }
     maven { url "http://repo.mikeprimm.com/" }
     maven { url "https://maven.enginehub.org/repo/" }
-    maven { url "https://plotsquared.com/mvn/" }
+    maven { url "https://mvn.intellectualsites.com/content/repositories/releases/" }
 }
 
 dependencies {
-    compileOnly(group: 'com.github.intellectualsites.PlotSquared', name: 'PlotSquared-Core', version: 'b9b0d89b5f759354a684cd7a6539ae7e4b883ba2') {
+    compileOnly(group: 'com.plotsquared', name: 'PlotSquared-Core', version: '5.12.0') {
         exclude(module: 'worldedit-core')
     }
     compile 'org.spigotmc:spigot-api:1.15.2-R0.1-SNAPSHOT'

--- a/src/main/java/com/empcraft/plot2dynmap/Main.java
+++ b/src/main/java/com/empcraft/plot2dynmap/Main.java
@@ -343,7 +343,7 @@ public class Main extends JavaPlugin implements Listener {
         }
         this.updatePeriod = per * 20;
         this.stop = false;
-        getServer().getScheduler().scheduleSyncDelayedTask(this, new Plot2Update(), 420);
+        getServer().getScheduler().runTaskLaterAsynchronously(this, new Plot2Update(), 420L);
     }
 
     private static final class AreaStyle {

--- a/src/main/java/com/empcraft/plot2dynmap/Main.java
+++ b/src/main/java/com/empcraft/plot2dynmap/Main.java
@@ -2,7 +2,6 @@ package com.empcraft.plot2dynmap;
 
 import com.plotsquared.core.PlotSquared;
 import com.plotsquared.core.plot.Plot;
-import com.plotsquared.core.plot.expiration.ExpireManager;
 import com.plotsquared.core.plot.flag.PlotFlag;
 import com.plotsquared.core.util.MainUtil;
 import com.sk89q.worldedit.regions.CuboidRegion;
@@ -31,7 +30,7 @@ import java.util.*;
  * @author Original: Empire92. Updated by Sauilitired
  */
 @SuppressWarnings("unused")
-public class Main extends JavaPlugin implements Listener {
+public class Main extends JavaPlugin implements Listener, Runnable {
 
     private static final String DEF_INFO_ELEMENT =
         "%key% <span style=\"font-weight:bold;\">%values%</span><br>";
@@ -176,7 +175,12 @@ public class Main extends JavaPlugin implements Listener {
         }
     }
 
-    private void updatePlots() {
+    @Override
+    public void run() {
+        if (stop) {
+            return;
+        }
+
         final Map<String, AreaMarker> newMap = new HashMap<>(); /* Build new map */
         try {
             for (final World w : getServer().getWorlds()) {
@@ -242,7 +246,7 @@ public class Main extends JavaPlugin implements Listener {
         this.resAreas = newMap;
 
         getServer().getScheduler()
-            .runTaskLaterAsynchronously(this, new Plot2Update(), this.updatePeriod);
+            .runTaskLaterAsynchronously(this, this, updatePeriod);
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
@@ -275,7 +279,6 @@ public class Main extends JavaPlugin implements Listener {
     }
 
     private void initialize() {
-
         MarkerAPI markerApi = this.dynAPI.getMarkerAPI();
         if (markerApi == null) {
             severe("Error loading dynmap-API");
@@ -343,7 +346,7 @@ public class Main extends JavaPlugin implements Listener {
         }
         this.updatePeriod = per * 20;
         this.stop = false;
-        getServer().getScheduler().runTaskLaterAsynchronously(this, new Plot2Update(), 420L);
+        getServer().getScheduler().runTaskLaterAsynchronously(this, this, 420L);
     }
 
     private static final class AreaStyle {
@@ -370,14 +373,6 @@ public class Main extends JavaPlugin implements Listener {
             this.strokeWeight = cfg.getInt(path + ".strokeWeight", 8);
             this.fillColor = cfg.getString(path + ".fillColor", "#FFFFFF");
             this.fillOpacity = cfg.getDouble(path + ".fillOpacity", 0.01);
-        }
-    }
-
-    private class Plot2Update implements Runnable {
-        @Override public void run() {
-            if (!Main.this.stop) {
-                updatePlots();
-            }
         }
     }
 }

--- a/src/main/java/com/empcraft/plot2dynmap/Main.java
+++ b/src/main/java/com/empcraft/plot2dynmap/Main.java
@@ -299,7 +299,7 @@ public class Main extends JavaPlugin implements Listener {
             return;
         }
 
-        final int minZoom = config.getInt("layer.getMinimumPoint().getZ()oom", 0);
+        final int minZoom = config.getInt("layer.minimumpoint.zoom", 0);
         if (minZoom > 0) {
             set.setMinZoom(minZoom);
         }

--- a/src/main/java/com/empcraft/plot2dynmap/Main.java
+++ b/src/main/java/com/empcraft/plot2dynmap/Main.java
@@ -1,12 +1,10 @@
 package com.empcraft.plot2dynmap;
 
 import com.plotsquared.core.PlotSquared;
-import com.plotsquared.core.player.PlotPlayer;
 import com.plotsquared.core.plot.Plot;
 import com.plotsquared.core.plot.expiration.ExpireManager;
 import com.plotsquared.core.plot.flag.PlotFlag;
 import com.plotsquared.core.util.MainUtil;
-import com.plotsquared.core.util.uuid.UUIDHandler;
 import com.sk89q.worldedit.regions.CuboidRegion;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
@@ -25,13 +23,7 @@ import org.dynmap.markers.AreaMarker;
 import org.dynmap.markers.MarkerAPI;
 import org.dynmap.markers.MarkerSet;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 
 /**
@@ -193,11 +185,9 @@ public class Main extends JavaPlugin implements Listener {
                     List<Plot> plots = new ArrayList<>(PlotSquared.get().getPlots(w.getName()));
                     if (plots.size() > 4096) {
                         plots.sort((a, b) -> {
-                            PlotPlayer p1 = UUIDHandler.getPlayer(a.guessOwner());
-                            PlotPlayer p2 = UUIDHandler.getPlayer(b.guessOwner());
-                            if (p1 == p2) {
-                                long l1 = ExpireManager.IMP.getAge(a.guessOwner());
-                                long l2 = ExpireManager.IMP.getAge(b.guessOwner());
+                            if (Objects.equals(a.getOwnerAbs(), b.getOwnerAbs())) {
+                                long l1 = ExpireManager.IMP.getAge(a.getOwnerAbs());
+                                long l2 = ExpireManager.IMP.getAge(b.getOwnerAbs());
                                 if (l1 == l2) {
                                     return Math.abs(a.hashCode()) - Math.abs(b.hashCode());
                                 }
@@ -212,18 +202,16 @@ public class Main extends JavaPlugin implements Listener {
                                 }
                                 return 1;
                             }
-                            if (p2 == null) {
+                            if (b.getOwnerAbs() == null) {
                                 return -1;
+                            } else {
+                                return 1;
                             }
-                            return 1;
                         });
                         plots = plots.subList(0, 4096);
                     }
                     for (final Plot plot : plots) {
-                        String owner = MainUtil.getName(plot.guessOwner());
-                        if (owner == null) {
-                            owner = "unknown";
-                        }
+                        String owner = MainUtil.getName(plot.getOwnerAbs());
                         final String[] helpers_list = new String[plot.getMembers().size()];
                         int i = 0;
                         for (UUID member : plot.getMembers()) {

--- a/src/main/java/com/empcraft/plot2dynmap/Main.java
+++ b/src/main/java/com/empcraft/plot2dynmap/Main.java
@@ -25,7 +25,6 @@ import org.dynmap.markers.MarkerSet;
 
 import java.util.*;
 
-
 /**
  * A lot of this code is reused from the examples provided by 'mikeprimm' - creator of dynmap
  *
@@ -182,35 +181,7 @@ public class Main extends JavaPlugin implements Listener {
         try {
             for (final World w : getServer().getWorlds()) {
                 if (PlotSquared.get().hasPlotArea(w.getName())) {
-                    List<Plot> plots = new ArrayList<>(PlotSquared.get().getPlots(w.getName()));
-                    if (plots.size() > 4096) {
-                        plots.sort((a, b) -> {
-                            if (Objects.equals(a.getOwnerAbs(), b.getOwnerAbs())) {
-                                long l1 = ExpireManager.IMP.getAge(a.getOwnerAbs());
-                                long l2 = ExpireManager.IMP.getAge(b.getOwnerAbs());
-                                if (l1 == l2) {
-                                    return Math.abs(a.hashCode()) - Math.abs(b.hashCode());
-                                }
-                                if (l2 == 0L) {
-                                    return -1;
-                                }
-                                if (l1 == 0L) {
-                                    return 1;
-                                }
-                                if (l1 > l2) {
-                                    return -1;
-                                }
-                                return 1;
-                            }
-                            if (b.getOwnerAbs() == null) {
-                                return -1;
-                            } else {
-                                return 1;
-                            }
-                        });
-                        plots = plots.subList(0, 4096);
-                    }
-                    for (final Plot plot : plots) {
+                    for (final Plot plot : new ArrayList<>(PlotSquared.get().getPlots(w.getName()))) {
                         String owner = MainUtil.getName(plot.getOwnerAbs());
                         final String[] helpers_list = new String[plot.getMembers().size()];
                         int i = 0;
@@ -401,7 +372,6 @@ public class Main extends JavaPlugin implements Listener {
             this.fillOpacity = cfg.getDouble(path + ".fillOpacity", 0.01);
         }
     }
-
 
     private class Plot2Update implements Runnable {
         @Override public void run() {

--- a/src/main/java/com/empcraft/plot2dynmap/Main.java
+++ b/src/main/java/com/empcraft/plot2dynmap/Main.java
@@ -59,7 +59,7 @@ public class Main extends JavaPlugin implements Listener, Runnable {
 
     private String formatInfoWindow(final PlotWrapper plot) {
         String v = "<div class=\"plotinfo\">" + this.infoWindow + "</div>";
-        v = v.replace("%id%", plot.getPlotId().x + "," + plot.getPlotId().y);
+        v = v.replace("%id%", plot.getPlotId().toCommaSeparatedString());
         v = v.replace("%alias%",
             this.infoElement.replace("%values%", StringEscapeUtils.escapeHtml(plot.getAlias()))
                 .replace("%key%", "Alias"));
@@ -127,7 +127,7 @@ public class Main extends JavaPlugin implements Listener, Runnable {
 
     private void handlePlot(final World world, final PlotWrapper plot,
         final Map<String, AreaMarker> newMap) {
-        final String name = plot.getPlotId().x + "," + plot.getPlotId().y;
+        final String name = plot.getPlotId().toCommaSeparatedString();
 
         double[] x;
         double[] z;


### PR DESCRIPTION
So, with https://github.com/IntellectualSites/PlotSquared/commit/37b065a097b05fe68502d5bfb113ad06390ecefe#diff-1c26cdc0e7fff2ae3e640c8bcbfa95b0L2398 guessOwner and the UUIDHandler have been removed, so I upgraded the plugin to use 5.12.0 functionalities.

I've taken the approach of https://github.com/IntellectualSites/PlotSquared-Expansion as to using jitpack as the dependency source while using the exact commit that denotes 5.12.0 (as there are no tags available) https://github.com/IntellectualSites/PlotSquared/commit/b9b0d89b5f759354a684cd7a6539ae7e4b883ba2

Note that I changed the comparison a bit because of PS-45 and the fact that comparing the UUIDs should yield the same result while being the more obvious solution. Also Objects.equals() works fine for null values.

The last diff is just because MainUtil.getName() returns unknown already (i.e. always returns a non-null value)

Closes https://issues.intellectualsites.com/issue/PS-28