### PR TITLE
fix: allow 0-width stroke width and 0-percent fill-opacity

### DIFF
--- a/src/main/java/com/plotsquared/plot2dynmap/Plot2DynmapPlugin.java
+++ b/src/main/java/com/plotsquared/plot2dynmap/Plot2DynmapPlugin.java
@@ -70,7 +70,10 @@ public class Plot2DynmapPlugin extends JavaPlugin implements Listener, Runnable 
                 this.infoElement.replace("%values%", StringEscapeUtils.escapeHtml(plot.flags())).replace("%key%", "Flags")
         );
         v = v.replace("%owner%", plot.owner());
-        v = v.replace("%creationdate%", this.infoElement.replace("%values%", plot.creationDate()).replace("%key%","Creation Date"));
+        v = v.replace(
+                "%creationdate%",
+                this.infoElement.replace("%values%", plot.creationDate()).replace("%key%", "Creation Date")
+        );
         v = v.replace("%rating%", this.infoElement.replace("%values%", plot.rating()).replace("%key%", "Rating"));
         return v;
     }
@@ -111,12 +114,8 @@ public class Plot2DynmapPlugin extends JavaPlugin implements Listener, Runnable 
         } catch (final NumberFormatException e) {
             e.printStackTrace();
         }
-        if (areaStyle.strokeWeight != 0) {
-            areaMarker.setLineStyle(areaStyle.strokeWeight, areaStyle.strokeOpacity, strokeColor);
-        }
-        if (areaStyle.fillOpacity != 0) {
-            areaMarker.setFillStyle(areaStyle.fillOpacity, fillColor);
-        }
+        areaMarker.setLineStyle(areaStyle.strokeWeight, areaStyle.strokeOpacity, strokeColor);
+        areaMarker.setFillStyle(areaStyle.fillOpacity, fillColor);
         if (areaStyle.label != null) {
             areaMarker.setLabel(areaStyle.label);
         }
@@ -247,7 +246,10 @@ public class Plot2DynmapPlugin extends JavaPlugin implements Listener, Runnable 
                         if (Double.isNaN(plot.getAverageRating())) {
                             rating = "NaN";
                         } else if (!Settings.General.SCIENTIFIC) {
-                            BigDecimal roundRating = BigDecimal.valueOf(plot.getAverageRating()).setScale(2, RoundingMode.HALF_UP);
+                            BigDecimal roundRating = BigDecimal.valueOf(plot.getAverageRating()).setScale(
+                                    2,
+                                    RoundingMode.HALF_UP
+                            );
                             rating = String.valueOf(roundRating);
                         } else {
                             rating = Double.toString(plot.getAverageRating());
@@ -255,7 +257,8 @@ public class Plot2DynmapPlugin extends JavaPlugin implements Listener, Runnable 
 
                         final PlotWrapper plotWrapper =
                                 new PlotWrapper(owner, helpers, trusted, denied, plot.getId(), alias, flags, plot.getArea(),
-                                        newDate, rating);
+                                        newDate, rating
+                                );
                         handlePlot(world, plotWrapper, newMap);
                     }
                 }

--- a/src/main/java/com/plotsquared/plot2dynmap/Plot2DynmapPlugin.java
+++ b/src/main/java/com/plotsquared/plot2dynmap/Plot2DynmapPlugin.java
@@ -108,14 +108,25 @@ public class Plot2DynmapPlugin extends JavaPlugin implements Listener, Runnable 
 
         int strokeColor = 0xFF0000;
         int fillColor = 0xFF0000;
+        double strokeOpacity = areaStyle.strokeOpacity;
+        double fillOpacity = areaStyle.fillOpacity;
         try {
             strokeColor = Integer.parseInt(areaStyle.strokeColor.substring(1), 16);
             fillColor = Integer.parseInt(areaStyle.fillColor.substring(1), 16);
         } catch (final NumberFormatException e) {
             e.printStackTrace();
         }
-        areaMarker.setLineStyle(areaStyle.strokeWeight, areaStyle.strokeOpacity, strokeColor);
-        areaMarker.setFillStyle(areaStyle.fillOpacity, fillColor);
+        // If 0-opacity or stroke weight, set the color to red with 0 percentage alpha channel to still be drawn and interactable
+        if (strokeOpacity == 0) {
+            strokeColor = 0xFF000000;
+            strokeOpacity = 1;
+        }
+        if (fillOpacity == 0) {
+            fillColor = 0xFF000000;
+            fillOpacity = 1;
+        }
+        areaMarker.setLineStyle(areaStyle.strokeWeight, strokeOpacity, strokeColor);
+        areaMarker.setFillStyle(fillOpacity, fillColor);
         if (areaStyle.label != null) {
             areaMarker.setLabel(areaStyle.label);
         }


### PR DESCRIPTION
## Overview

Based on an issue on discord 
![grafik](https://user-images.githubusercontent.com/27054324/151228782-7344cf50-88d5-4296-af73-69e40e726c7f.png)

## Description
Now a 0-width stroke width and 0-percent fill-opacity is possible + code reformat 

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] I tested my changes and approved their functionality.
- [x] I ensured my changes do not break other parts of the code
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)

## Maintainer checklist
<!-- Leave this blank, it's for project maintainers -->
Before the changes are marked as `Ready for merge`: 

- [ ] There are at least 2 approvals from project developers or maintainers for the pull request and no outstanding requests for change
- [ ] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically
- [ ] If the change needs additional modification steps from users, e.g. for permission changes, make sure the entry is added to the pull request description so it can be appended to the changelog.
