### PR TITLE
Pin GH actions to SHA to avoid mutable refs

### DIFF
--- a/.github/workflows/announce-release-on-discord.yml
+++ b/.github/workflows/announce-release-on-discord.yml
@@ -2,7 +2,6 @@ name: Announce release on discord
 on:
   release:
     types: [published]
-
 jobs:
   send_announcement:
     runs-on: ubuntu-latest
@@ -11,7 +10,7 @@ jobs:
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
           DISCORD_USERNAME: Plot2Dynmap Release
-        uses: Ilshidur/action-discord@0.3.2
+        uses: Ilshidur/action-discord@0c4b27844ba47cb1c7bee539c8eead5284ce9fa9 # ratchet:Ilshidur/action-discord@0.3.2
         with:
           args: |
             "<@&673138796690276352>"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,5 @@
 name: build
-
-on: [ pull_request, push ]
-
+on: [pull_request, push]
 jobs:
   build:
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
@@ -10,7 +8,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@55e685c48d84285a5b0418cd094606e199cca3b6 # v1
       - name: Setup Java
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,12 +1,10 @@
 name: "CodeQL"
-
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
-
+    branches: [main]
 jobs:
   analyze:
     name: Analyze
@@ -15,23 +13,18 @@ jobs:
       actions: read
       contents: read
       security-events: write
-
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'java' ]
-
+        language: ['java']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@32dc499307d133bb5085bae78498c0ac2cf762d5 # v2
         with:
           languages: ${{ matrix.language }}
-
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
-
+        uses: github/codeql-action/autobuild@32dc499307d133bb5085bae78498c0ac2cf762d5 # v2
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@32dc499307d133bb5085bae78498c0ac2cf762d5 # v2

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,15 +1,12 @@
 name: draft release
-
 on:
   push:
     branches:
       - main
   pull_request:
-    types: [ opened, reopened, synchronize ]
+    types: [opened, reopened, synchronize]
   pull_request_target:
-    types: [ opened, reopened, synchronize ]
-
-
+    types: [opened, reopened, synchronize]
 jobs:
   update_release_draft:
     if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/upload-release-asset.yml
+++ b/.github/workflows/upload-release-asset.yml
@@ -1,17 +1,15 @@
 name: Upload release assets
-
 on:
   release:
     types: [published]
-
 jobs:
   upload_asset:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
-      - name : Validate Gradle Wrapper
-        uses : gradle/wrapper-validation-action@v1
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@55e685c48d84285a5b0418cd094606e199cca3b6 # v1
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
@@ -21,7 +19,7 @@ jobs:
       - name: Clean Build
         run: ./gradlew clean build
       - name: Upload Release Assets
-        uses: AButler/upload-release-assets@v2.0
+        uses: AButler/upload-release-assets@ec6d3263266dc57eb6645b5f75e827987f7c217d # ratchet:AButler/upload-release-assets@v2.0
         with:
           files: 'build/libs/Plot2Dynmap-*.jar'
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
GitHub actions are mutable if not pinned, which allow modifications without revision changes. Let's pin external versions to ensure the version specified matches the version GH action pulls.